### PR TITLE
Removes the node project package file

### DIFF
--- a/myrailsapp/package.json
+++ b/myrailsapp/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "myrailsapp",
-  "private": true,
-  "dependencies": {}
-}


### PR DESCRIPTION
This file is useful for node projects not rails projects.

I know that the setup instructions that this tutorial is tied to asks the learner to run `hab plan init -s ruby`. If you were to forget to include that flag `hab plan init` will find that this is a node project and want to use the node scaffolding.

Signed-off-by: Franklin Webber <franklin@chef.io>